### PR TITLE
docs: rebrand LambdaTest to TestMu AI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,13 +634,19 @@ For additional help:
 
 Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
-**🔄 Our Rebrand Journey**
+### 🔄 Our Rebrand Journey
+
+In 2017, we introduced LambdaTest with a clear mission: to become the world's most trusted cloud testing platform. We built a scalable, high-performance test cloud that eliminated flakiness, improved developer feedback cycles, and accelerated release velocity for teams worldwide.
+
+As LambdaTest grew, we expanded the platform into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the entire testing lifecycle. These capabilities enabled teams to test any stack, on any technology, at enterprise scale.
+
+Over time, we rebuilt the architecture to be AI-native from the ground up. What began as LambdaTest's high-performance testing cloud has now evolved into TestMu AI, an AI-native, multi-agent platform redefining modern quality engineering.
 
 We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
 👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
 
-**🔭 Explore TestMu AI**
+### 🔭 Explore TestMu AI
 
 The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SmartUI SDK Sample for Selenium JavaScript
+# SmartUI SDK Sample for Selenium JavaScript — TestMu AI (Formerly LambdaTest)
 
 Welcome to the SmartUI SDK sample for Selenium JavaScript. This repository demonstrates how to integrate SmartUI visual regression testing with Selenium JavaScript.
 
@@ -19,7 +19,7 @@ smartui-node-sample/
 ### Prerequisites
 
 - Node.js installed
-- LambdaTest account credentials (for Cloud tests)
+- TestMu AI account credentials (for Cloud tests)
 - Chrome browser (for Local tests)
 
 ### Environment Setup
@@ -102,9 +102,9 @@ npx smartui exec node sdkLocal.js
 npx smartui exec node sdkCloud.js
 ```
 
-## Testing with LambdaTest Hooks
+## Testing with TestMu AI Hooks
 
-This repository also includes examples for using SmartUI with LambdaTest Hooks integration. Hooks-based integration allows you to use SmartUI directly within your existing LambdaTest Cloud automation tests without requiring the SmartUI CLI.
+This repository also includes examples for using SmartUI with TestMu AI Hooks integration. Hooks-based integration allows you to use SmartUI directly within your existing TestMu AI Cloud automation tests without requiring the SmartUI CLI.
 
 ### SDK vs Hooks: Which Approach to Use?
 
@@ -116,19 +116,19 @@ This repository also includes examples for using SmartUI with LambdaTest Hooks i
 - ✅ Requires `PROJECT_TOKEN` environment variable
 
 **Hooks Approach (Recommended for Cloud-Only Testing):**
-- ✅ Works only with LambdaTest Cloud Grid
-- ✅ No CLI required - direct integration with LambdaTest
-- ✅ Uses LambdaTest capabilities for configuration
-- ✅ Better for existing LambdaTest automation suites
+- ✅ Works only with TestMu AI Cloud Grid
+- ✅ No CLI required - direct integration with TestMu AI
+- ✅ Uses TestMu AI capabilities for configuration
+- ✅ Better for existing TestMu AI automation suites
 - ✅ Requires `LT_USERNAME` and `LT_ACCESS_KEY` environment variables
 
 ### Hooks Integration Setup
 
 **Location:** See the `hooks` folder, where you can see all the `examples` scripts to setup your suite or run the demo.
 
-**Purpose:** Enhance visual regression capabilities in your LambdaTest web automation tests running on LambdaTest Cloud Grid.
+**Purpose:** Enhance visual regression capabilities in your TestMu AI web automation tests running on TestMu AI Cloud Grid.
 
-**Documentation:** [LambdaTest Selenium Visual Regression Documentation](https://www.lambdatest.com/support/docs/selenium-visual-regression-testing/).
+**Documentation:** [TestMu AI Selenium Visual Regression Documentation](https://www.testmuai.com/support/docs/selenium-visual-regression-testing/).
 
 ### Hooks Setup Steps
 
@@ -143,7 +143,7 @@ npm i selenium-webdriver
 
 #### 2. Configure Environment Variables
 
-Set your LambdaTest credentials:
+Set your TestMu AI credentials:
 
 ```bash
 export LT_USERNAME='your_username'
@@ -187,9 +187,9 @@ let capabilities = {
 };
 ```
 
-#### 4. Connect to LambdaTest Grid
+#### 4. Connect to TestMu AI Grid
 
-Create a WebDriver instance connected to LambdaTest Cloud:
+Create a WebDriver instance connected to TestMu AI Cloud:
 
 ```javascript
 const GRID_HOST = "@hub.lambdatest.com/wd/hub";
@@ -299,7 +299,7 @@ The `smartUI.options` in capabilities supports various configuration options:
 
 ### View Hooks Results
 
-After running your hooks-based tests, visit the [LambdaTest Automation Dashboard](https://automation.lambdatest.com/) to view:
+After running your hooks-based tests, visit the [TestMu AI Automation Dashboard](https://automation.lambdatest.com/) to view:
 - Test execution status
 - Screenshots captured
 - Visual comparison results
@@ -311,7 +311,7 @@ Navigate to your SmartUI project in the [SmartUI Dashboard](https://smartui.lamb
 
 ### Cloud Test (`sdk/sdkCloud.js`)
 
-- Connects to LambdaTest Cloud using Selenium Remote WebDriver
+- Connects to TestMu AI Cloud using Selenium Remote WebDriver
 - Reads credentials from environment variables (`LT_USERNAME`, `LT_ACCESS_KEY`)
 - Takes screenshot with name: `screenshot`
 
@@ -505,7 +505,7 @@ echo $PROJECT_TOKEN
    echo $LT_USERNAME
    echo $LT_ACCESS_KEY
    ```
-2. Check your credentials in [LambdaTest Profile Settings](https://accounts.lambdatest.com/profile)
+2. Check your credentials in [TestMu AI Profile Settings](https://accounts.lambdatest.com/profile)
 3. Ensure there are no extra spaces or quotes in the environment variables
 
 ### Issue: `Cannot find module '@lambdatest/selenium-driver'`
@@ -614,16 +614,35 @@ After running the tests, visit your SmartUI project dashboard to view the captur
 
 ## Additional Resources
 
-- [SmartUI Selenium JavaScript Onboarding Guide](https://www.lambdatest.com/support/docs/smartui-onboarding-selenium-js/)
-- [LambdaTest Selenium Documentation](https://www.lambdatest.com/support/docs/selenium-automation/)
+- [SmartUI Selenium JavaScript Onboarding Guide](https://www.testmuai.com/support/docs/smartui-onboarding-selenium-js/)
+- [TestMu AI Selenium Documentation](https://www.testmuai.com/support/docs/selenium-automation/)
 - [SmartUI Dashboard](https://smartui.lambdatest.com/)
-- [LambdaTest Automation Dashboard](https://automation.lambdatest.com/)
-- [LambdaTest Community](https://community.lambdatest.com/)
-- [LambdaTest Blog](https://www.lambdatest.com/blog/)
+- [TestMu AI Automation Dashboard](https://automation.lambdatest.com/)
+- [TestMu AI Community](https://community.testmuai.com/)
+- [TestMu AI Blog](https://www.testmuai.com/blog/)
 
 ## Support
 
 For additional help:
-- [LambdaTest Support](https://www.lambdatest.com/support/)
-- [Documentation](https://www.lambdatest.com/support/docs/)
-- [24/7 Chat Support](https://www.lambdatest.com/)
+- [TestMu AI Support](https://www.testmuai.com/support/)
+- [Documentation](https://www.testmuai.com/support/docs/)
+- [24/7 Chat Support](https://www.testmuai.com/)
+
+## 🚀 [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/)
+
+👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, LambdaTest has officially rebranded to TestMu AI. We have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
+
+Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
+
+**🔄 Our Rebrand Journey**
+
+We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
+
+**✨ Specialties**
+
+- 🤖 AI-Native Test Execution (Formerly LambdaTest)
+- ⚡ Autonomous Test Automation
+- 🌐 Cross-Browser & Mobile Testing
+- 📊 Unified Quality Intelligence
+
+👉 Find [LambdaTest's New Home](https://www.testmuai.com/).

--- a/README.md
+++ b/README.md
@@ -1,658 +1,115 @@
-# SmartUI SDK Sample for Selenium JavaScript — TestMu AI (Formerly LambdaTest)
+# Run SmartUI Visual Tests with Selenium and Node.js on TestMu AI (Formerly LambdaTest)
 
-Welcome to the SmartUI SDK sample for Selenium JavaScript. This repository demonstrates how to integrate SmartUI visual regression testing with Selenium JavaScript.
+<p align="center">
+  <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
+  <a href="https://www.npmjs.com/package/selenium-webdriver"><img src="https://img.shields.io/npm/v/selenium-webdriver.svg?style=for-the-badge&labelColor=000000" alt="selenium-webdriver version"></a>
+  <a href="https://community.testmuai.com/"><img src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&labelColor=000000" alt="Community"></a>
+</p>
 
-## Repository Structure
+## Getting Started
 
-```
-smartui-node-sample/
-├── sdk/
-│   ├── sdkCloud.js          # Cloud test
-│   ├── sdkLocal.js          # Local test
-│   └── smartui-web.json     # SmartUI config (create with npx smartui config:create)
-└── hooks/                    # Hooks integration examples
-    └── examples/             # Hooks examples
-```
+[TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks. 
 
-## 1. Prerequisites and Environment Setup
+With TestMu AI (Formerly LambdaTest), you can run SmartUI visual regression tests with Selenium and Node.js on real browsers. This sample shows how to configure Node.js + Selenium + SmartUI to run on the TestMu AI cloud.
+
+- [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
+- Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.
 
 ### Prerequisites
 
-- Node.js installed
-- TestMu AI account credentials (for Cloud tests)
-- Chrome browser (for Local tests)
+- Node.js and npm (latest stable)
+- A TestMu AI (Formerly LambdaTest) account with your username and access key
 
-### Environment Setup
+### Setup
 
-**For Cloud:**
-```bash
-export LT_USERNAME='your_username'
-export LT_ACCESS_KEY='your_access_key'
-export PROJECT_TOKEN='your_project_token'
-```
-
-**For Local:**
-```bash
-export PROJECT_TOKEN='your_project_token'
-```
-
-## 2. Initial Setup and Dependencies
-
-### Clone the Repository
+Clone and install dependencies:
 
 ```bash
-git clone https://github.com/LambdaTest/smartui-node-sample
-cd smartui-node-sample/sdk
+git clone https://github.com/LambdaTest/smartui-node-sample && cd smartui-node-sample
+cd sdk && npm install
 ```
 
-### Install Dependencies
+Set your credentials as environment variables.
 
-Install the required dependencies:
+**macOS / Linux:**
 
 ```bash
-npm i @lambdatest/smartui-cli @lambdatest/selenium-driver selenium-webdriver
+export LT_USERNAME="YOUR_USERNAME"
+export LT_ACCESS_KEY="YOUR_ACCESS_KEY"
+export LT_TUNNEL="YOUR_TUNNEL_NAME"
+export PROJECT_TOKEN="YOUR_PROJECT_TOKEN"
 ```
 
-**Dependencies included:**
-- `@lambdatest/smartui-cli` - SmartUI CLI
-- `@lambdatest/selenium-driver` - SmartUI SDK for Selenium JavaScript
-- `selenium-webdriver` - Selenium WebDriver
-
-**Note**: To ensure seamless execution of ES6 modules, add `"type": "module"` to your `package.json` file.
-
-### Create SmartUI Configuration
+**Windows:**
 
 ```bash
-npx smartui config:create smartui-web.json
+set LT_USERNAME="YOUR_USERNAME"
+set LT_ACCESS_KEY="YOUR_ACCESS_KEY"
+set LT_TUNNEL="YOUR_TUNNEL_NAME"
+set PROJECT_TOKEN="YOUR_PROJECT_TOKEN"
 ```
 
-## 3. Steps to Integrate Screenshot Commands into Codebase
-
-The SmartUI screenshot function is already implemented in the repository.
-
-**Cloud Test** (`sdk/sdkCloud.js`):
-```javascript
-import { smartuiSnapshot } from '@lambdatest/selenium-driver';
-
-await driver.get('https://www.lambdatest.com');
-await smartuiSnapshot(driver, "screenshot");
-```
-
-**Local Test** (`sdk/sdkLocal.js`):
-```javascript
-import { smartuiSnapshot } from '@lambdatest/selenium-driver';
-
-await driver.get('https://www.lambdatest.com');
-await smartuiSnapshot(driver, "screenshot");
-```
-
-**Note**: The code is already configured and ready to use. You can modify the URL and screenshot name if needed.
-
-## 4. Execution and Commands
-
-### Local Execution
+### Run tests
 
 ```bash
-npx smartui exec node sdkLocal.js
+node sdkCloud.js
 ```
 
-### Cloud Execution
+View results on your TestMu AI dashboard.
 
-```bash
-npx smartui exec node sdkCloud.js
+### Local testing with TestMu AI Tunnel
+
+To test locally hosted apps, set up the TestMu AI tunnel. OS-specific guides:
+
+- [Local Testing on Windows](https://www.testmuai.com/support/docs/local-testing-for-windows/)
+- [Local Testing on macOS](https://www.testmuai.com/support/docs/local-testing-for-macos/)
+- [Local Testing on Linux](https://www.testmuai.com/support/docs/local-testing-for-linux/)
+
+Add the following to your capabilities:
+
+```js
+tunnel: true,
 ```
 
-## Testing with TestMu AI Hooks
+## Contributions
 
-This repository also includes examples for using SmartUI with TestMu AI Hooks integration. Hooks-based integration allows you to use SmartUI directly within your existing TestMu AI Cloud automation tests without requiring the SmartUI CLI.
+Contributions are welcome. Open an issue to discuss your idea before submitting a pull request. When reporting bugs, include your Node.js version, OS, and selenium-webdriver version.
 
-### SDK vs Hooks: Which Approach to Use?
+## TestMu AI (Formerly LambdaTest) Community
 
-**SDK Approach (Recommended for Local Testing):**
-- ✅ Works with both local and cloud execution
-- ✅ Uses SmartUI CLI for configuration and execution
-- ✅ Supports multiple browsers and viewports via `smartui-web.json`
-- ✅ Better for CI/CD integration
-- ✅ Requires `PROJECT_TOKEN` environment variable
+Connect with testers and developers in the [TestMu AI Community](https://community.testmuai.com/). Ask questions, share what you are building, and discuss best practices in test automation and DevOps.
+  
+## TestMu AI (Formerly LambdaTest) Certifications
 
-**Hooks Approach (Recommended for Cloud-Only Testing):**
-- ✅ Works only with TestMu AI Cloud Grid
-- ✅ No CLI required - direct integration with TestMu AI
-- ✅ Uses TestMu AI capabilities for configuration
-- ✅ Better for existing TestMu AI automation suites
-- ✅ Requires `LT_USERNAME` and `LT_ACCESS_KEY` environment variables
+Earn free [TestMu AI Certifications](https://www.testmuai.com/certifications/) for testers, developers, and QA engineers. Validate your skills in Selenium, Cypress, Playwright, Appium, Espresso and more. Industry-recognized, shareable on LinkedIn, and built by practitioners, not marketers.
 
-### Hooks Integration Setup
+## Learning Resources by TestMu AI (Formerly LambdaTest)
 
-**Location:** See the `hooks` folder, where you can see all the `examples` scripts to setup your suite or run the demo.
+Learn modern testing through tutorials, guides, videos, and weekly updates:
 
-**Purpose:** Enhance visual regression capabilities in your TestMu AI web automation tests running on TestMu AI Cloud Grid.
+* [TestMu AI Blog](https://www.testmuai.com/blog/)
+* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/)
+* [TestMu AI on YouTube](https://www.youtube.com/@TestMuAI)
+* [TestMu AI Newsletter](https://www.testmuai.com/newsletter/)
+  
+## LambdaTest is Now TestMu AI
 
-**Documentation:** [TestMu AI Selenium Visual Regression Documentation](https://www.testmuai.com/support/docs/selenium-visual-regression-testing/).
+On **January 12, 2026**, [LambdaTest evolved to TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/), the world's first fully autonomous **Agentic AI Quality Engineering Platform**.
 
-### Hooks Setup Steps
+Same team. Same infrastructure. Same customer accounts. All existing LambdaTest logins, scripts, capabilities, and integrations continue to work without change.
 
-#### 1. Install Dependencies
+ð Find the new home for [LambdaTest](https://www.testmuai.com).
 
-Navigate to the hooks directory and install dependencies:
+### How LambdaTest Evolved into TestMu AI
 
-```bash
-cd hooks
-npm i selenium-webdriver
-```
+In 2017, we launched LambdaTest with a simple mission: make testing fast, reliable, and accessible. As LambdaTest grew, we expanded into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the full depth of the testing lifecycle.
 
-#### 2. Configure Environment Variables
+As software development entered the AI era, testing had to evolve, too. We rebuilt the architecture to be AI-native from the ground up, with autonomous agents that **plan, author, execute, analyze, and optimize tests** while keeping humans in the loop. The platform integrates with your repos, CI, IDEs, and terminals, continuously learning from every code change and development signal.
 
-Set your TestMu AI credentials:
+That evolution earned a new name: **TestMu AI**, built for an AI-first future of quality engineering. TestMu is not a new name for us. It is the name of our annual community conference, which has brought together 100,000+ quality engineers to discuss how AI would reshape testing, long before that became an industry norm. 
 
-```bash
-export LT_USERNAME='your_username'
-export LT_ACCESS_KEY='your_access_key'
-```
-
-#### 3. Configure Capabilities
-
-In your test file (e.g., `hooks/examples/test.js`), configure the capabilities with SmartUI options:
-
-```javascript
-const USERNAME = process.env.LT_USERNAME;
-const KEY = process.env.LT_ACCESS_KEY;
-
-let capabilities = {
-  platform: "Windows 10",
-  browserName: "chrome",
-  version: "latest",
-  visual: true,  // Enable visual testing
-  "user": USERNAME,
-  "accessKey": KEY,
-  name: "test session",
-  build: "Automation Build",
-  "LT:Options": {
-    "smartUI.project": "<Your Project Name>",  // Your SmartUI project name
-    "smartUI.build": "<Your Build Name>",      // Optional: Build name
-    "smartUI.baseline": false,                 // Set to true to update baseline
-    "smartUI.options": {
-      "output": {
-        "errorColor": { "red": 200, "green": 0, "blue": 255 },
-        "errorType": "movement",
-        "transparency": 0.3,
-        "largeImageThreshold": 100,
-        "useCrossOrigin": false,
-        "outputDiff": true
-      },
-      "scaleToSameSize": true,
-      "ignore": "antialiasing"
-    }
-  }
-};
-```
-
-#### 4. Connect to TestMu AI Grid
-
-Create a WebDriver instance connected to TestMu AI Cloud:
-
-```javascript
-const GRID_HOST = "@hub.lambdatest.com/wd/hub";
-const gridUrl = `https://${USERNAME}:${KEY}${GRID_HOST}`;
-
-const driver = await new webdriver.Builder()
-  .usingServer(gridUrl)
-  .withCapabilities(capabilities)
-  .build();
-```
-
-#### 5. Add Screenshot Hooks
-
-Use `driver.executeScript()` to capture screenshots at any point in your test:
-
-```javascript
-// Navigate to your page
-await driver.get('https://www.lambdatest.com');
-
-// Take a screenshot with basic configuration
-let config = {
-  screenshotName: 'homepage-screenshot'
-};
-await driver.executeScript("smartui.takeScreenshot", config);
-
-// Take a full-page screenshot
-let fullPageConfig = {
-  screenshotName: 'homepage-full-page',
-  fullPage: true
-};
-await driver.executeScript("smartui.takeScreenshot", fullPageConfig);
-
-// Take a screenshot with custom options
-let customConfig = {
-  screenshotName: 'homepage-custom',
-  fullPage: true,
-  ignore: ["antialiasing", "colors"],
-  boundingBoxes: [{ x: 100, y: 100, width: 200, height: 200 }]
-};
-await driver.executeScript("smartui.takeScreenshot", customConfig);
-```
-
-#### 6. Run the Test
-
-Execute your test script:
-
-```bash
-node hooks/examples/test.js
-```
-
-### Advanced Hooks Examples
-
-#### Multiple Screenshots in One Test
-
-```javascript
-await driver.get('https://www.lambdatest.com');
-
-// Screenshot 1: Homepage
-await driver.executeScript("smartui.takeScreenshot", {
-  screenshotName: 'homepage'
-});
-
-// Navigate and take another screenshot
-await driver.get('https://www.lambdatest.com/pricing');
-await driver.executeScript("smartui.takeScreenshot", {
-  screenshotName: 'pricing-page'
-});
-```
-
-#### Screenshot with Ignore Areas
-
-```javascript
-let config = {
-  screenshotName: 'homepage-ignored',
-  ignore: ["antialiasing"],
-  ignoredBoxes: [
-    { x: 0, y: 0, width: 100, height: 50 }  // Ignore header area
-  ]
-};
-await driver.executeScript("smartui.takeScreenshot", config);
-```
-
-#### Screenshot with Bounding Boxes (Compare Specific Area)
-
-```javascript
-let config = {
-  screenshotName: 'homepage-bounded',
-  boundingBoxes: [
-    { x: 100, y: 200, width: 800, height: 400 }  // Compare only this area
-  ]
-};
-await driver.executeScript("smartui.takeScreenshot", config);
-```
-
-### Hooks Configuration Options
-
-The `smartUI.options` in capabilities supports various configuration options:
-
-- **errorColor**: RGB values for highlighting differences
-- **errorType**: Type of error detection (`"movement"`, `"flat"`, `"flatDifferenceIntensity"`, `"movementDifferenceIntensity"`, `"diffOnly"`)
-- **transparency**: Opacity of the error overlay (0.0 to 1.0)
-- **largeImageThreshold**: Threshold for large image comparison
-- **useCrossOrigin**: Enable cross-origin resource sharing
-- **outputDiff**: Generate difference images
-- **scaleToSameSize**: Scale images to same size before comparison
-- **ignore**: Ignore specific visual artifacts (`"antialiasing"`, `"colors"`, `"less"`, `"alpha"`, `"nothing"`)
-
-### View Hooks Results
-
-After running your hooks-based tests, visit the [TestMu AI Automation Dashboard](https://automation.lambdatest.com/) to view:
-- Test execution status
-- Screenshots captured
-- Visual comparison results
-- Build and session details
-
-Navigate to your SmartUI project in the [SmartUI Dashboard](https://smartui.lambdatest.com/) to see detailed visual regression results.
-
-## Test Files
-
-### Cloud Test (`sdk/sdkCloud.js`)
-
-- Connects to TestMu AI Cloud using Selenium Remote WebDriver
-- Reads credentials from environment variables (`LT_USERNAME`, `LT_ACCESS_KEY`)
-- Takes screenshot with name: `screenshot`
-
-### Local Test (`sdk/sdkLocal.js`)
-
-- Runs Selenium locally using Chrome
-- Requires Chrome browser installed
-- Takes screenshot with name: `screenshot`
-
-## Configuration
-
-### SmartUI Config (`smartui-web.json`)
-
-Create the SmartUI configuration file using:
-```bash
-npx smartui config:create smartui-web.json
-```
-
-## Best Practices
-
-### Screenshot Naming
-
-- Use descriptive, unique names for each screenshot
-- Include page/component name and state (e.g., `homepage-logged-in`, `checkout-step-2`)
-- Avoid special characters that might cause issues in URLs
-- Use consistent naming conventions across your test suite
-
-### When to Take Screenshots
-
-- **Critical user flows**: Login, checkout, payment
-- **Dynamic content**: After user interactions, form submissions
-- **Responsive breakpoints**: Different viewport sizes
-- **State changes**: Before and after important actions
-
-### Performance Optimization
-
-- Take screenshots only when necessary (not on every page load)
-- Use `waitForPageRender` in `smartui-web.json` for slow-loading pages
-- Consider viewport-specific screenshots instead of full-page when possible
-- Use ignore options to reduce false positives from dynamic content
-
-### Error Handling
-
-```javascript
-try {
-  await driver.get('https://www.lambdatest.com');
-  await smartuiSnapshot(driver, "homepage");
-} catch (error) {
-  console.error('Screenshot failed:', error);
-  // Handle error appropriately
-  throw error;
-} finally {
-  await driver.quit();
-}
-```
-
-## Common Use Cases
-
-### Multiple Screenshots in Sequence
-
-```javascript
-await driver.get('https://www.lambdatest.com');
-await smartuiSnapshot(driver, "homepage");
-
-await driver.findElement(By.linkText('Pricing')).click();
-await smartuiSnapshot(driver, "pricing-page");
-
-await driver.findElement(By.linkText('Documentation')).click();
-await smartuiSnapshot(driver, "documentation-page");
-```
-
-### Screenshot After User Interaction
-
-```javascript
-await driver.get('https://www.lambdatest.com');
-
-// Wait for element and interact
-const searchBox = await driver.findElement(By.id('search'));
-await searchBox.sendKeys('Selenium');
-await searchBox.sendKeys(Key.RETURN);
-
-// Wait for results to load
-await driver.wait(until.elementLocated(By.className('results')), 10000);
-
-// Take screenshot after interaction
-await smartuiSnapshot(driver, "search-results");
-```
-
-### Conditional Screenshots
-
-```javascript
-const isLoggedIn = await driver.findElements(By.className('user-menu')).length > 0;
-
-if (isLoggedIn) {
-  await smartuiSnapshot(driver, "homepage-logged-in");
-} else {
-  await smartuiSnapshot(driver, "homepage-guest");
-}
-```
-
-## CI/CD Integration
-
-### GitHub Actions Example
-
-```yaml
-name: SmartUI Visual Tests
-
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-
-jobs:
-  visual-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18'
-      
-      - name: Install dependencies
-        run: |
-          cd sdk
-          npm ci
-      
-      - name: Run SmartUI tests
-        env:
-          PROJECT_TOKEN: ${{ secrets.SMARTUI_PROJECT_TOKEN }}
-          LT_USERNAME: ${{ secrets.LT_USERNAME }}
-          LT_ACCESS_KEY: ${{ secrets.LT_ACCESS_KEY }}
-        run: |
-cd sdk
-          npx smartui exec node sdkCloud.js
-```
-
-### Jenkins Pipeline Example
-
-```groovy
-pipeline {
-    agent any
-    
-    environment {
-        PROJECT_TOKEN = credentials('smartui-project-token')
-        LT_USERNAME = credentials('lambdatest-username')
-        LT_ACCESS_KEY = credentials('lambdatest-access-key')
-    }
-    
-    stages {
-        stage('Install Dependencies') {
-            steps {
-                sh 'cd sdk && npm ci'
-            }
-        }
-        
-        stage('Run Visual Tests') {
-            steps {
-                sh 'cd sdk && npx smartui exec node sdkCloud.js'
-            }
-        }
-    }
-}
-```
-
-## Troubleshooting
-
-### Issue: `Error: SmartUI Config already exists: smartui-web.json`
-
-**Solution**: This is informational. The config file already exists. You can:
-- Use the existing config file
-- Delete it and create a new one: `rm smartui-web.json && npx smartui config:create smartui-web.json`
-- Use a different config file: `npx smartui --config custom-config.json exec ...`
-
-### Issue: `PROJECT_TOKEN is required`
-
-**Solution**: Ensure the `PROJECT_TOKEN` environment variable is set:
-```bash
-export PROJECT_TOKEN='your_project_token'
-# Verify it's set
-echo $PROJECT_TOKEN
-```
-
-### Issue: `Unauthorized, either Username or AccessKey is invalid` (Cloud)
-
-**Solution**: 
-1. Verify your credentials are set correctly:
-   ```bash
-   echo $LT_USERNAME
-   echo $LT_ACCESS_KEY
-   ```
-2. Check your credentials in [TestMu AI Profile Settings](https://accounts.lambdatest.com/profile)
-3. Ensure there are no extra spaces or quotes in the environment variables
-
-### Issue: `Cannot find module '@lambdatest/selenium-driver'`
-
-**Solution**: Install dependencies:
-```bash
-cd sdk
-npm install @lambdatest/smartui-cli @lambdatest/selenium-driver selenium-webdriver
-```
-
-### Issue: Screenshots not appearing in SmartUI Dashboard
-
-**Solution**:
-1. Verify the `PROJECT_TOKEN` matches your SmartUI project
-2. Check that the build completed successfully (no errors in terminal)
-3. Wait a few moments for screenshots to process
-4. Verify you're looking at the correct project in the dashboard
-
-### Issue: `ChromeDriver version mismatch` (Local)
-
-**Solution**: 
-1. Update ChromeDriver: `npm install --save-dev chromedriver`
-2. Or use WebDriver Manager: `npm install --save-dev webdriver-manager`
-3. Ensure Chrome browser is up to date
-
-### Issue: Timeout errors when taking screenshots
-
-**Solution**: 
-1. Increase `waitForPageRender` in `smartui-web.json`:
-   ```json
-   {
-     "web": {
-       "waitForPageRender": 60000
-     }
-   }
-   ```
-2. Add explicit waits before taking screenshots:
-   ```javascript
-   await driver.wait(until.elementLocated(By.id('main-content')), 10000);
-   await smartuiSnapshot(driver, "screenshot");
-   ```
-
-### Issue: False positives in visual comparisons
-
-**Solution**:
-1. Use ignore options for dynamic content (ads, timestamps, etc.)
-2. Increase `waitForTimeout` in `smartui-web.json` for lazy-loaded content
-3. Use viewport-specific screenshots instead of full-page when appropriate
-4. Review and update baseline screenshots when intentional changes are made
-
-## Configuration Tips
-
-### Optimizing `smartui-web.json`
-
-```json
-{
-  "web": {
-    "browsers": ["chrome", "firefox"],
-    "viewports": [
-      [1920, 1080],
-      [1366, 768],
-      [360, 640]
-    ],
-    "waitForPageRender": 30000,
-    "waitForTimeout": 2000
-  }
-}
-```
-
-**Tips**:
-- Start with fewer browsers/viewports for faster initial testing
-- Adjust `waitForPageRender` based on your page load times
-- Use `waitForTimeout` for async components (lazy-loaded images, animations)
-
-### Environment-Specific Configuration
-
-Create different config files for different environments:
-
-```bash
-# Development
-npx smartui --config smartui-dev.json exec node sdkLocal.js
-
-# Staging
-npx smartui --config smartui-staging.json exec node sdkCloud.js
-
-# Production
-npx smartui --config smartui-prod.json exec node sdkCloud.js
-```
-
-## View Results
-
-After running the tests, visit your SmartUI project dashboard to view the captured screenshots and compare them with baseline builds.
-
-### Understanding Results
-
-- **Baseline Created**: First run creates baseline screenshots
-- **Passed**: Screenshot matches baseline (no visual differences)
-- **Failed**: Visual differences detected
-- **Review Required**: Manual review needed for differences
-
-### Managing Baselines
-
-- Update baseline when intentional UI changes are made
-- Review failed comparisons to identify false positives
-- Use ignore options to exclude known dynamic content
-
-## Additional Resources
-
-- [SmartUI Selenium JavaScript Onboarding Guide](https://www.testmuai.com/support/docs/smartui-onboarding-selenium-js/)
-- [TestMu AI Selenium Documentation](https://www.testmuai.com/support/docs/selenium-automation/)
-- [SmartUI Dashboard](https://smartui.lambdatest.com/)
-- [TestMu AI Automation Dashboard](https://automation.lambdatest.com/)
-- [TestMu AI Community](https://community.testmuai.com/)
-- [TestMu AI Blog](https://www.testmuai.com/blog/)
+What started as a high-performance cloud testing platform has transformed into an AI-native, multi-agent system powering a connected, end-to-end quality layer. That evolution defined a new identity: LambdaTest evolved into TestMu AI, built for an AI-first future of quality engineering.
 
 ## Support
 
-For additional help:
-- [TestMu AI Support](https://www.testmuai.com/support/)
-- [Documentation](https://www.testmuai.com/support/docs/)
-- [24/7 Chat Support](https://www.testmuai.com/)
-
-## 🚀 LambdaTest is Now TestMu AI
-
-👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/) - we have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
-
-Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
-
-### 🔄 Our Rebrand Journey
-
-In 2017, we introduced LambdaTest with a clear mission: to become the world's most trusted cloud testing platform. We built a scalable, high-performance test cloud that eliminated flakiness, improved developer feedback cycles, and accelerated release velocity for teams worldwide.
-
-As LambdaTest grew, we expanded the platform into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the entire testing lifecycle. These capabilities enabled teams to test any stack, on any technology, at enterprise scale.
-
-Over time, we rebuilt the architecture to be AI-native from the ground up. What began as LambdaTest's high-performance testing cloud has now evolved into TestMu AI, an AI-native, multi-agent platform redefining modern quality engineering.
-
-We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
-
-👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
-
-### 🔭 Explore TestMu AI
-
-The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
-
-- [KaneAI](https://www.testmuai.com/kane-ai/)
-- [Agent-to-Agent Testing](https://www.testmuai.com/agent-to-agent-testing/)
-- [HyperExecute](https://www.testmuai.com/hyperexecute/)
-- [Real Device Cloud](https://www.testmuai.com/real-device-cloud/)
-- [Pricing](https://www.testmuai.com/pricing/)
-- [Documentation](https://www.testmuai.com/support/docs/)
+Got a question? Email [support@testmuai.com](mailto:support@testmuai.com) or chat with us 24x7 from our chat portal.

--- a/README.md
+++ b/README.md
@@ -628,9 +628,9 @@ For additional help:
 - [Documentation](https://www.testmuai.com/support/docs/)
 - [24/7 Chat Support](https://www.testmuai.com/)
 
-## 🚀 [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/)
+## 🚀 LambdaTest is Now TestMu AI
 
-👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, LambdaTest has officially rebranded to TestMu AI. We have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
+👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/) - we have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
 
 Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
@@ -638,11 +638,15 @@ Whether you have been part of the LambdaTest community for years or are just dis
 
 We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
-**✨ Specialties**
-
-- 🤖 AI-Native Test Execution (Formerly LambdaTest)
-- ⚡ Autonomous Test Automation
-- 🌐 Cross-Browser & Mobile Testing
-- 📊 Unified Quality Intelligence
-
 👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
+
+**🔭 Explore TestMu AI**
+
+The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
+
+- [KaneAI](https://www.testmuai.com/kane-ai/)
+- [Agent-to-Agent Testing](https://www.testmuai.com/agent-to-agent-testing/)
+- [HyperExecute](https://www.testmuai.com/hyperexecute/)
+- [Real Device Cloud](https://www.testmuai.com/real-device-cloud/)
+- [Pricing](https://www.testmuai.com/pricing/)
+- [Documentation](https://www.testmuai.com/support/docs/)


### PR DESCRIPTION
## Summary

- Updated README to reflect LambdaTest to TestMu AI rebrand (January 2026)
- H1 heading updated to [Title] - TestMu AI (Formerly LambdaTest)
- Replaced LambdaTest with TestMu AI in all prose (skipping GitHub org URLs, package names, config file names, code blocks, and service subdomains)
- Community URL updated to community.testmuai.com
- YouTube channel updated to youtube.com/@TestMuAI
- Support email updated to support@testmuai.com
- Added rebrand section: LambdaTest is Now TestMu AI

Generated with Claude Code