### PR TITLE
fix(smartui): install SmartUI CLI 4.1.77 by default (TE-22391)

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -37,7 +37,7 @@ git clone https://github.com/LambdaTest/smartui-node-sample
 Install required NPM modules for `LambdaTest Smart UI Selenium SDK` in your **Frontend** project.
 
 ```bash
-npm i @lambdatest/smartui-cli @lambdatest/selenium-driver selenium-webdriver
+npm i @lambdatest/smartui-cli@latest @lambdatest/selenium-driver selenium-webdriver
 ```
 
 <b>To ensure seamless execution of ES6 modules within our repository, it is essential to configure the Node.js environment to recognize ES6 module syntax. This is accomplished by specifying the module type in your `package.json` file.</b>

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@lambdatest/selenium-driver": "^1.0.2",
-    "@lambdatest/smartui-cli": "latest",
+    "@lambdatest/smartui-cli": "^4.1.77",
     "selenium-webdriver": "^4.16.0"
   },
   "name": "sdk",


### PR DESCRIPTION
## Summary

Part of [TE-22391](https://lambdatest.atlassian.net/browse/TE-22391).

Users following this sample could end up on an outdated SmartUI CLI, which is a known cause of visual rendering issues and a recurring source of support tickets.

### What was wrong

This repository already resolved correctly, but the `latest` spec is fragile: it silently yields to any committed lockfile.

### Changes

- `package.json`: pin `@lambdatest/smartui-cli` to `^4.1.77`
- Install commands now use `@lambdatest/smartui-cli@latest` (1 occurrence)

### Verification

`npm install --dry-run` resolves `@lambdatest/smartui-cli 4.1.77` both before and after. This change is preventative.

### A note on `@latest`

Adding `@latest` to a bare `npm install <package>` does not change what gets installed: npm already resolves an unversioned package name to the `latest` dist-tag. It is included here for explicitness, but on its own it does not fix the stale-CLI problem. The dependency manifest is what actually determines the installed version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5pDePdJgs3Ms7qpjKc4kU

[TE-22391]: https://lambdatest.atlassian.net/browse/TE-22391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ